### PR TITLE
Docker/smaller images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,4 @@ RUN cd /src && go build -tags netgo -a -v -o gladius-edged -i cmd/gladius-edged/
 FROM alpine
 WORKDIR /app
 COPY --from=build-env /src/gladius-edged /app/
+ENTRYPOINT ./gladius-edged

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ RUN cd /src && go build -tags netgo -a -v -o gladius-edged -i cmd/gladius-edged/
 # final stage
 FROM alpine
 WORKDIR /app
+VOLUME /root/.gladius
 COPY --from=build-env /src/gladius-edged /app/
 ENTRYPOINT ./gladius-edged

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM golang:1.11.4
+# build stage
+FROM golang:1.11.4 AS build-env
+ADD . /src
+RUN cd /src && go build -tags netgo -a -v -o gladius-edged -i cmd/gladius-edged/main.go
 
+# final stage
+FROM alpine
 WORKDIR /app
-
-COPY . .
-
-VOLUME /root/.gladius
-
-RUN go build -o app -i cmd/gladius-edged/main.go
-
-CMD ["./app"]
+COPY --from=build-env /src/gladius-edged /app/


### PR DESCRIPTION
Shrank the docker image from 1gb to 16mb with a multistage build.